### PR TITLE
Update Tooling

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="composer-normalize" version="^2.15.0" installed="2.30.2" copy="false" location="./tools/composer-normalize"/>
-  <phar name="phpunit" version="^10.0" installed="10.1.2" location="./tools/phpunit.phar" copy="false"/>
-  <phar name="phpstan" version="^1.0" installed="1.10.12" copy="false" location="./tools/phpstan"/>
+  <phar name="composer-normalize" version="^2.15.0" installed="2.45.0" copy="false" location="./tools/composer-normalize"/>
+  <phar name="phpunit" version="^10.0" installed="10.5.45" location="./tools/phpunit.phar" copy="false"/>
+  <phar name="phpstan" version="^1.0" installed="1.12.23" copy="false" location="./tools/phpstan"/>
   <phar name="overtrue/phplint" version="^9.0.4" installed="9.0.4" location="./tools/phplint" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="composer-normalize" version="^2.15.0" installed="2.45.0" copy="false" location="./tools/composer-normalize"/>
   <phar name="phpunit" version="^10.0" installed="10.5.45" location="./tools/phpunit.phar" copy="false"/>
-  <phar name="phpstan" version="^1.0" installed="1.12.23" copy="false" location="./tools/phpstan"/>
+  <phar name="phpstan" version="^2.0" installed="2.1.11" copy="false" location="./tools/phpstan"/>
   <phar name="overtrue/phplint" version="^9.0.4" installed="9.0.4" location="./tools/phplint" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -3,5 +3,4 @@
   <phar name="composer-normalize" version="^2.15.0" installed="2.45.0" copy="false" location="./tools/composer-normalize"/>
   <phar name="phpunit" version="^10.0" installed="10.5.45" location="./tools/phpunit.phar" copy="false"/>
   <phar name="phpstan" version="^2.0" installed="2.1.11" copy="false" location="./tools/phpstan"/>
-  <phar name="overtrue/phplint" version="^9.0.4" installed="9.0.4" location="./tools/phplint" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"phpcompatibility/php-compatibility": "^9.3",
 		"squizlabs/php_codesniffer": "^3.0",
-		"composer/composer": "^2.0"
+		"composer/composer": "^2.0",
+    "overtrue/phplint": "^9.0"
 	},
 	"minimum-stability": "stable",
 	"prefer-stable": true,
@@ -62,7 +63,7 @@
 		],
 		"analyse:compabilitycheck": "vendor/bin/phpcs --standard=./phpcs.compabilitycheck.xml",
 		"analyse:phpcs": "vendor/bin/phpcs",
-		"analyse:phplint": "tools/phplint",
+		"analyse:phplint": "vendor/bin/phplint",
 		"analyse:phpstan": "tools/phpstan analyse",
 		"cs-fix": [
 			"@cs-fix:phpcbf"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"phpcompatibility/php-compatibility": "^9.3",
 		"squizlabs/php_codesniffer": "^3.0",
 		"composer/composer": "^2.0",
-    "overtrue/phplint": "^9.0"
+		"overtrue/phplint": "^9.0"
 	},
 	"minimum-stability": "stable",
 	"prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"php": ">=8.0 <8.5",
 		"ext-json": "*",
 		"composer-plugin-api": "^2.0",
-		"symfony/console": "^6.0"
+		"symfony/console": "^6.0 || ^7.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "889ccaa19f423e42b2102516e82bf8b2",
+    "content-hash": "8d958debfd5c9e4c6302b02a7182690d",
     "packages": [
         {
             "name": "psr/container",
@@ -1574,6 +1574,99 @@
             "time": "2024-11-28T04:54:44+00:00"
         },
         {
+            "name": "overtrue/phplint",
+            "version": "9.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/overtrue/phplint.git",
+                "reference": "3fdc395a816d1401091062c7a3bfb31252aed6c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/overtrue/phplint/zipball/3fdc395a816d1401091062c7a3bfb31252aed6c5",
+                "reference": "3fdc395a816d1401091062c7a3bfb31252aed6c5",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^8.1",
+                "symfony/cache": "^6.4 || ^7.0",
+                "symfony/console": "^6.4 || ^7.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.0",
+                "symfony/finder": "^6.4 || ^7.0",
+                "symfony/options-resolver": "^6.4 || ^7.0",
+                "symfony/process": "^6.4 || ^7.0",
+                "symfony/yaml": "^6.4 || ^7.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4",
+                "brainmaestro/composer-git-hooks": "^3.0.0",
+                "jetbrains/phpstorm-stubs": "^2024.1",
+                "php-parallel-lint/php-console-highlighter": "^1.0"
+            },
+            "bin": [
+                "bin/phplint"
+            ],
+            "type": "library",
+            "extra": {
+                "hooks": {
+                    "pre-commit": [
+                        "composer style:fix",
+                        "composer code:check"
+                    ]
+                },
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true,
+                    "target-directory": "vendor-bin"
+                },
+                "branch-alias": {
+                    "dev-main": "9.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Overtrue\\PHPLint\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "overtrue",
+                    "email": "anzhengchao@gmail.com"
+                },
+                {
+                    "name": "Laurent Laville",
+                    "homepage": "https://github.com/llaville"
+                }
+            ],
+            "description": "`phplint` is a tool that can speed up linting of php files by running several lint processes at once.",
+            "keywords": [
+                "check",
+                "lint",
+                "phplint",
+                "static analysis",
+                "syntax"
+            ],
+            "support": {
+                "issues": "https://github.com/overtrue/phplint/issues",
+                "source": "https://github.com/overtrue/phplint/tree/9.5.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/overtrue",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-15T05:41:15+00:00"
+        },
+        {
             "name": "phpcompatibility/php-compatibility",
             "version": "9.3.5",
             "source": {
@@ -1634,6 +1727,105 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
             "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/log",
@@ -2016,6 +2208,336 @@
             "time": "2025-03-18T05:04:51+00:00"
         },
         {
+            "name": "symfony/cache",
+            "version": "v7.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "9131e3018872d2ebb6fe8a9a4d6631273513d42c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/9131e3018872d2ebb6fe8a9a4d6631273513d42c",
+                "reference": "9131e3018872d2ebb6fe8a9a4d6631273513d42c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/cache": "^2.0|^3.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^2.5|^3",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/var-dumper": "<6.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "2.0|3.0",
+                "psr/simple-cache-implementation": "1.0|2.0|3.0",
+                "symfony/cache-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "classmap": [
+                    "Traits/ValueWrapper.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v7.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-25T15:54:33+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b",
+                "reference": "15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/cache": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
             "name": "symfony/filesystem",
             "version": "v7.2.0",
             "source": {
@@ -2144,6 +2666,73 @@
                 }
             ],
             "time": "2024-12-30T19:00:17+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "7da8fbac9dcfef75ffc212235d76b2754ce0cf50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/7da8fbac9dcfef75ffc212235d76b2754ce0cf50",
+                "reference": "7da8fbac9dcfef75ffc212235d76b2754ce0cf50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-20T11:17:29+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -2437,6 +3026,154 @@
                 }
             ],
             "time": "2025-03-13T12:21:46+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v7.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "c37b301818bd7288715d40de634f05781b686ace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/c37b301818bd7288715d40de634f05781b686ace",
+                "reference": "c37b301818bd7288715d40de634f05781b686ace",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v7.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-13T12:21:46+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "4c4b6f4cfcd7e52053f0c8bfad0f7f30fb924912"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4c4b6f4cfcd7e52053f0c8bfad0f7f30fb924912",
+                "reference": "4c4b6f4cfcd7e52053f0c8bfad0f7f30fb924912",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-03T07:12:39+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5ff0f22d84a675e5356f371b8d050fb",
+    "content-hash": "889ccaa19f423e42b2102516e82bf8b2",
     "packages": [
         {
             "name": "psr/container",
@@ -61,47 +61,46 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.15",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f1fc6f47283e27336e7cebb9e8946c8de7bff9bd"
+                "reference": "e51498ea18570c062e7df29d05a7003585b19b88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f1fc6f47283e27336e7cebb9e8946c8de7bff9bd",
-                "reference": "f1fc6f47283e27336e7cebb9e8946c8de7bff9bd",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e51498ea18570c062e7df29d05a7003585b19b88",
+                "reference": "e51498ea18570c062e7df29d05a7003585b19b88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.2",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/string": "^6.4|^7.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
                 "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -135,7 +134,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.15"
+                "source": "https://github.com/symfony/console/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -151,7 +150,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T14:19:14+00:00"
+            "time": "2025-03-12T08:11:12+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -172,12 +171,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "3.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -562,12 +561,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "3.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -712,16 +711,16 @@
     "packages-dev": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.4",
+            "version": "1.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "bc0593537a463e55cadf45fd938d23b75095b7e1"
+                "reference": "f65c239c970e7f072f067ab78646e9f0b2935175"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/bc0593537a463e55cadf45fd938d23b75095b7e1",
-                "reference": "bc0593537a463e55cadf45fd938d23b75095b7e1",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/f65c239c970e7f072f067ab78646e9f0b2935175",
+                "reference": "f65c239c970e7f072f067ab78646e9f0b2935175",
                 "shasum": ""
             },
             "require": {
@@ -768,7 +767,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.4"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.6"
             },
             "funding": [
                 {
@@ -784,20 +783,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-27T15:35:25+00:00"
+            "time": "2025-03-06T14:30:56+00:00"
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.5.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915"
+                "reference": "134b705ddb0025d397d8318a75825fe3c9d1da34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
-                "reference": "4b0a223cf5be7c9ee7e0ef1bc7db42b4a97c9915",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/134b705ddb0025d397d8318a75825fe3c9d1da34",
+                "reference": "134b705ddb0025d397d8318a75825fe3c9d1da34",
                 "shasum": ""
             },
             "require": {
@@ -841,7 +840,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.5.0"
+                "source": "https://github.com/composer/class-map-generator/tree/1.6.1"
             },
             "funding": [
                 {
@@ -857,20 +856,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-25T16:11:06+00:00"
+            "time": "2025-03-24T13:50:44+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "2.8.4",
+            "version": "2.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "112e37d1dca22b3fdb81cf3524ab4994f47fdb8c"
+                "reference": "fc06c099955929ac67270d169e8b5fb83ad53807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/112e37d1dca22b3fdb81cf3524ab4994f47fdb8c",
-                "reference": "112e37d1dca22b3fdb81cf3524ab4994f47fdb8c",
+                "url": "https://api.github.com/repos/composer/composer/zipball/fc06c099955929ac67270d169e8b5fb83ad53807",
+                "reference": "fc06c099955929ac67270d169e8b5fb83ad53807",
                 "shasum": ""
             },
             "require": {
@@ -881,7 +880,7 @@
                 "composer/semver": "^3.3",
                 "composer/spdx-licenses": "^1.5.7",
                 "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
-                "justinrainbow/json-schema": "^5.3",
+                "justinrainbow/json-schema": "^6.3.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "react/promise": "^2.11 || ^3.2",
@@ -955,7 +954,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.8.4"
+                "source": "https://github.com/composer/composer/tree/2.8.7"
             },
             "funding": [
                 {
@@ -971,7 +970,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-11T10:57:47+00:00"
+            "time": "2025-04-03T14:26:28+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -1069,13 +1068,13 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                },
                 "phpstan": {
                     "includes": [
                         "extension.neon"
                     ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -1428,30 +1427,40 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.3.0",
+            "version": "6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8"
+                "reference": "16b274cb469bc8165c59b76c283724a035d27f4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
-                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/16b274cb469bc8165c59b76c283724a035d27f4c",
+                "reference": "16b274cb469bc8165c59b76c283724a035d27f4c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-json": "*",
+                "marc-mabe/php-enum": "^4.0",
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "friendsofphp/php-cs-fixer": "3.3.0",
                 "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.35"
+                "marc-mabe/php-enum-phpstan": "^2.0",
+                "phpspec/prophecy": "^1.19",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^8.5"
             },
             "bin": [
                 "bin/validate-json"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "JsonSchema\\": "src/JsonSchema/"
@@ -1480,16 +1489,89 @@
                 }
             ],
             "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
+            "homepage": "https://github.com/jsonrainbow/json-schema",
             "keywords": [
                 "json",
                 "schema"
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/5.3.0"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.4.0"
             },
-            "time": "2024-07-06T21:00:26+00:00"
+            "time": "2025-04-01T18:50:59+00:00"
+        },
+        {
+            "name": "marc-mabe/php-enum",
+            "version": "v4.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "7159809e5cfa041dca28e61f7f7ae58063aae8ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/7159809e5cfa041dca28e61f7f7ae58063aae8ed",
+                "reference": "7159809e5cfa041dca28e61f7f7ae58063aae8ed",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16.10 || ^1.0.4",
+                "phpstan/phpstan": "^1.3.1",
+                "phpunit/phpunit": "^7.5.20 | ^8.5.22 | ^9.5.11",
+                "vimeo/psalm": "^4.17.0 | ^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.2-dev",
+                    "dev-master": "4.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "https://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enumerator",
+                "enummap",
+                "enumset",
+                "map",
+                "set",
+                "type",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.1"
+            },
+            "time": "2024-11-28T04:54:44+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1851,16 +1933,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.2",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079"
+                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1368f4a58c3c52114b86b1abe8f4098869cb0079",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
+                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
                 "shasum": ""
             },
             "require": {
@@ -1925,9 +2007,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-12-11T16:04:26+00:00"
+            "time": "2025-03-18T05:04:51+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1997,16 +2083,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.2.0",
+            "version": "v7.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "6de263e5868b9a137602dd1e33e4d48bfae99c49"
+                "reference": "87a71856f2f56e4100373e92529eed3171695cfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/6de263e5868b9a137602dd1e33e4d48bfae99c49",
-                "reference": "6de263e5868b9a137602dd1e33e4d48bfae99c49",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/87a71856f2f56e4100373e92529eed3171695cfb",
+                "reference": "87a71856f2f56e4100373e92529eed3171695cfb",
                 "shasum": ""
             },
             "require": {
@@ -2041,7 +2127,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.2.0"
+                "source": "https://github.com/symfony/finder/tree/v7.2.2"
             },
             "funding": [
                 {
@@ -2057,7 +2143,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-23T06:56:12+00:00"
+            "time": "2024-12-30T19:00:17+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -2293,16 +2379,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.2.0",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d34b22ba9390ec19d2dd966c40aa9e8462f27a7e"
+                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d34b22ba9390ec19d2dd966c40aa9e8462f27a7e",
-                "reference": "d34b22ba9390ec19d2dd966c40aa9e8462f27a7e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/87b7c93e57df9d8e39a093d32587702380ff045d",
+                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d",
                 "shasum": ""
             },
             "require": {
@@ -2334,7 +2420,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.2.0"
+                "source": "https://github.com/symfony/process/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -2350,7 +2436,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T14:24:19+00:00"
+            "time": "2025-03-13T12:21:46+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.compabilitycheck.xml
+++ b/phpcs.compabilitycheck.xml
@@ -2,7 +2,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 
-	<config name="testVersion" value="8.0-8.3"/>
+	<config name="testVersion" value="8.0-8.4"/>
 
 	<arg name="basepath" value="."/>
 	<arg name="cache" value="var/cache/phpcs.json"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 
-	<config name="testVersion" value="8.0-8.2"/>
+	<config name="testVersion" value="8.0-8.4"/>
 
 	<arg name="basepath" value="."/>
 	<arg name="cache" value="var/cache/phpcs.json"/>
@@ -13,8 +13,6 @@
 
 	<file>src/</file>
 	<file>tests/</file>
-
-	<bootstrap>vendor/autoload.php</bootstrap>
 
 	<rule ref="PSR12"/>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-	level: 6
+	level: 9
 	tmpDir: var/cache/phpstan
 	paths:
 		- src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,12 @@
 	cacheResultFile="var/cache/phpunit.result.cache"
 	colors="true"
 	executionOrder="random"
-	bootstrap="vendor/autoload.php">
+	bootstrap="vendor/autoload.php"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+>
   <coverage cacheDirectory="var/cache/phpunit.coverage.cache">
     <report>
 	    <html outputDirectory="var/log/clover"/>

--- a/src/Git/Executor.php
+++ b/src/Git/Executor.php
@@ -29,8 +29,8 @@ class Executor
 
         $proc = proc_open($command, $descriptorspec, $pipes, $this->workdir, $env);
         if (is_resource($proc)) {
-            $stdout = trim(stream_get_contents($pipes[1]));
-            $stderr = trim(stream_get_contents($pipes[2]));
+            $stdout = trim(stream_get_contents($pipes[1]) ?: "");
+            $stderr = trim(stream_get_contents($pipes[2]) ?: "");
             $exitCode = proc_close($proc);
             if ($exitCode !== 0) {
                 throw new \RuntimeException(

--- a/src/Plugin/Commands/BaseCommand.php
+++ b/src/Plugin/Commands/BaseCommand.php
@@ -15,7 +15,7 @@ abstract class BaseCommand extends \Composer\Command\BaseCommand
 
     private ?ReleaseManagement $releaseManagement = null;
 
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         parent::__construct($name);
     }

--- a/src/Plugin/Commands/StartHotfixCommand.php
+++ b/src/Plugin/Commands/StartHotfixCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SP\Composer\Project\Plugin\Commands;
 
 use Composer\Console\Input\InputArgument;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -24,6 +25,9 @@ class StartHotfixCommand extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $tag = $input->getArgument('tag');
+        if (!is_string($tag)) {
+            throw new RuntimeException("Invalid tag");
+        }
         $version = $this->getReleaseManagement()->startHotfix($tag);
 
         $io = new SymfonyStyle($input, $output);

--- a/src/Project.php
+++ b/src/Project.php
@@ -24,7 +24,7 @@ class Project
 
     private Platform $platform;
 
-    public function __construct(RootPackageInterface $package, GitProvider $gitProvider, Platform $platform = null)
+    public function __construct(RootPackageInterface $package, GitProvider $gitProvider, ?Platform $platform = null)
     {
         $this->gitProvider = $gitProvider;
         $this->package = $package;

--- a/src/ReleaseManagement.php
+++ b/src/ReleaseManagement.php
@@ -93,6 +93,9 @@ class ReleaseManagement
         }
 
         $releaseVersion = $this->project->getNextReleaseVersion();
+        if ($releaseVersion === null) {
+            throw new \RuntimeException("Unable to determine release version");
+        }
 
         $this->assertNoUncommittedChanges('The release can only be created when all changes are committed.');
 

--- a/tests/Git/StandardGitProviderTest.php
+++ b/tests/Git/StandardGitProviderTest.php
@@ -165,7 +165,9 @@ class StandardGitProviderTest extends TestCase
             );
             $files = new RecursiveIteratorIterator($dirObj, RecursiveIteratorIterator::CHILD_FIRST);
             foreach ($files as $path) {
-                $path->isDir() && !$path->isLink() ? rmdir($path->getPathname()) : unlink($path->getPathname());
+                if ($path instanceof \SplFileInfo) {
+                    $path->isDir() && !$path->isLink() ? rmdir($path->getPathname()) : unlink($path->getPathname());
+                }
             }
             rmdir($dirPath);
         }

--- a/tests/Plugin/Commands/ReleaseCommandTest.php
+++ b/tests/Plugin/Commands/ReleaseCommandTest.php
@@ -3,15 +3,14 @@
 namespace SP\Composer\Project\Plugin\Commands;
 
 use Composer\Console\Application;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SP\Composer\Project\ReleaseManagement;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * @covers \SP\Composer\Project\Plugin\Commands\ReleaseCommand
- */
+#[CoversClass(ReleaseCommand::class)]
 class ReleaseCommandTest extends TestCase
 {
     public function testCommand(): void

--- a/tests/Plugin/Commands/ReleaseVersionCommandTest.php
+++ b/tests/Plugin/Commands/ReleaseVersionCommandTest.php
@@ -3,6 +3,7 @@
 namespace SP\Composer\Project\Plugin\Commands;
 
 use Composer\Console\Application;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SP\Composer\Project\Project;
 use SP\Composer\Project\ReleaseManagement;
@@ -10,9 +11,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * @covers \SP\Composer\Project\Plugin\Commands\ReleaseVersionCommand
- */
+#[CoversClass(ReleaseVersionCommand::class)]
 class ReleaseVersionCommandTest extends TestCase
 {
     public function testCommand(): void

--- a/tests/Plugin/Commands/StartHotfixCommandTest.php
+++ b/tests/Plugin/Commands/StartHotfixCommandTest.php
@@ -3,15 +3,14 @@
 namespace SP\Composer\Project\Plugin\Commands;
 
 use Composer\Console\Application;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SP\Composer\Project\ReleaseManagement;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * @covers \SP\Composer\Project\Plugin\Commands\StartHotfixCommand
- */
+#[CoversClass(StartHotfixCommand::class)]
 class StartHotfixCommandTest extends TestCase
 {
     public function testCommand(): void

--- a/tests/Plugin/Commands/VerifyReleaseCommandTest.php
+++ b/tests/Plugin/Commands/VerifyReleaseCommandTest.php
@@ -3,15 +3,14 @@
 namespace SP\Composer\Project\Plugin\Commands;
 
 use Composer\Console\Application;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SP\Composer\Project\ReleaseManagement;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * @covers \SP\Composer\Project\Plugin\Commands\VerifyReleaseCommand
- */
+#[CoversClass(VerifyReleaseCommand::class)]
 class VerifyReleaseCommandTest extends TestCase
 {
     public function testCommand(): void

--- a/tests/Plugin/Commands/VersionCommandTest.php
+++ b/tests/Plugin/Commands/VersionCommandTest.php
@@ -3,15 +3,14 @@
 namespace SP\Composer\Project\Plugin\Commands;
 
 use Composer\Console\Application;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SP\Composer\Project\Project;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * @covers \SP\Composer\Project\Plugin\Commands\VersionCommand
- */
+#[CoversClass(VersionCommand::class)]
 class VersionCommandTest extends TestCase
 {
     public function testCommand(): void

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -4,122 +4,87 @@ namespace SP\Composer\Project;
 
 use Composer\Package\Link;
 use Composer\Package\RootPackageInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use SP\Composer\Project\Git\GitProvider;
 
-/**
- * @covers \SP\Composer\Project\Project
- */
+#[CoversClass(Project::class)]
 class ProjectTest extends TestCase
 {
-    /**
-     * @throws Exception
-     */
     public function testGetName(): void
     {
         $rootPackage = $this->createStub(RootPackageInterface::class);
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
-
         $git = $this->createStub(GitProvider::class);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("foo", $project->getName());
         $this->assertEquals("sitepark", $project->getVendor());
     }
 
-    /**
-     * @throws Exception
-     */
     public function testBaseFilename(): void
     {
         $rootPackage = $this->createStub(RootPackageInterface::class);
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->createStub(GitProvider::class);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("sitepark-foo", $project->getBaseFilename());
     }
 
-    /**
-     * @throws Exception
-     */
     public function testGetFeatureBranchName(): void
     {
         $rootPackage = $this->createStub(RootPackageInterface::class);
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->createStub(GitProvider::class);
         $git->method('getCurrentBranch')->willReturn("feature/my-feature");
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("my-feature", $project->getFeatureBranchName());
     }
 
-    /**
-     * @throws Exception
-     */
+
     public function testGetVersionQualifier(): void
     {
         $rootPackage = $this->createStub(RootPackageInterface::class);
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->createStub(GitProvider::class);
         $git->method('isDev')->willReturn(true);
         $git->method('getCurrentBranch')->willReturn("feature/my-feature");
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("my-feature-SNAPSHOT", $project->getVersionQualifier());
     }
 
-    /**
-     * @throws Exception
-     */
     public function testGetBranch(): void
     {
         $rootPackage = $this->createStub(RootPackageInterface::class);
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->createStub(GitProvider::class);
         $git->method('getCurrentBranch')->willReturn("main");
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("main", $project->getBranch());
     }
 
-    /**
-     * @throws Exception
-     */
     public function testGetBranches(): void
     {
         $rootPackage = $this->createStub(RootPackageInterface::class);
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->createStub(GitProvider::class);
         $git->method('getBranches')->willReturn(["main", "support/1.x"]);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals(["main", "support/1.x"], $project->getBranches());
     }
 
-    /**
-     * @throws Exception
-     */
     public function testGetUnstableDependencies(): void
     {
         $platform = $this->createStub(Platform::class);
@@ -129,31 +94,24 @@ class ProjectTest extends TestCase
         $package = $this->createStub(Link::class);
         $package->method('getPrettyConstraint')->willReturn('dev-develop');
         $package->method('getTarget')->willReturn('sitepark/bar');
-        /** @var Link $package */
+
         $rootPackage = $this->createStub(RootPackageInterface::class);
         $rootPackage->method('getName')->willReturn('sitepark/foo');
         $rootPackage->method('getRequires')->willReturn([$package]);
-        /** @var RootPackageInterface $rootPackage */
 
-        /** @var GitProvider $git */
         $git = $this->createStub(GitProvider::class);
 
         $project = new Project($rootPackage, $git, $platform);
         $this->assertEquals(['sitepark/bar:dev-develop'], $project->getUnstableDependencies());
     }
 
-    /**
-     * @throws Exception
-     */
     public function testHasBranche(): void
     {
         $rootPackage = $this->createStub(RootPackageInterface::class);
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->createStub(GitProvider::class);
         $git->method('getBranches')->willReturn(["main", "support/1.x"]);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertTrue($project->hasBranch('support/1.x'));
@@ -163,7 +121,6 @@ class ProjectTest extends TestCase
     {
         $rootPackage = $this->getMockBuilder(RootPackageInterface::class)->getMock();
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->getMockBuilder(GitProvider::class)->getMock();
         $git->method('getCurrentBranch')->willReturn('main');
@@ -171,7 +128,6 @@ class ProjectTest extends TestCase
             '1.0.0',
             '1.1.0'
         ]);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("1.2.0", $project->getNextReleaseVersion());
@@ -181,7 +137,6 @@ class ProjectTest extends TestCase
     {
         $rootPackage = $this->getMockBuilder(RootPackageInterface::class)->getMock();
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->getMockBuilder(GitProvider::class)->getMock();
         $git->method('getCurrentBranch')->willReturn('support/2.x');
@@ -190,7 +145,6 @@ class ProjectTest extends TestCase
             '2.0.1',
             '2.1.0',
         ]);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("2.2.0", $project->getNextReleaseVersion());
@@ -200,7 +154,6 @@ class ProjectTest extends TestCase
     {
         $rootPackage = $this->getMockBuilder(RootPackageInterface::class)->getMock();
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->getMockBuilder(GitProvider::class)->getMock();
         $git->method('getCurrentBranch')->willReturn('hotfix/1.1.x');
@@ -209,7 +162,6 @@ class ProjectTest extends TestCase
             '1.1.1',
             '1.1.2'
         ]);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("1.1.3", $project->getNextReleaseVersion());
@@ -219,7 +171,6 @@ class ProjectTest extends TestCase
     {
         $rootPackage = $this->getMockBuilder(RootPackageInterface::class)->getMock();
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->getMockBuilder(GitProvider::class)->getMock();
         $git->method('getCurrentBranch')->willReturn('hotfix/1.1.x');
@@ -227,7 +178,6 @@ class ProjectTest extends TestCase
             '1.1.0',
             '1.1.1'
         ]);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("1.1.1", $project->getVersion());
@@ -237,7 +187,7 @@ class ProjectTest extends TestCase
     {
         $rootPackage = $this->getMockBuilder(RootPackageInterface::class)->getMock();
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
+
 
         $git = $this->getMockBuilder(GitProvider::class)->getMock();
         $git->method('isDev')->willReturn(true);
@@ -247,7 +197,7 @@ class ProjectTest extends TestCase
             '1.1.0',
             '1.2.0'
         ]);
-        /** @var GitProvider $git */
+
         $project = new Project($rootPackage, $git);
         $this->assertEquals("1.3.0", $project->getVersion());
     }
@@ -256,7 +206,6 @@ class ProjectTest extends TestCase
     {
         $rootPackage = $this->getMockBuilder(RootPackageInterface::class)->getMock();
         $rootPackage->method('getName')->willReturn('sitepark/foo');
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->getMockBuilder(GitProvider::class)->getMock();
         $git->method('getCurrentBranch')->willReturn('develop');
@@ -265,7 +214,6 @@ class ProjectTest extends TestCase
             '1.0.0',
             '1.1.0'
         ]);
-        /** @var GitProvider $git */
 
         $project = new Project($rootPackage, $git);
         $this->assertEquals("1.2.0", $project->getVersion());
@@ -280,7 +228,6 @@ class ProjectTest extends TestCase
                 'dev-develop' => '2.x-dev'
             ]
         ]);
-        /** @var RootPackageInterface $rootPackage */
 
         $git = $this->getMockBuilder(GitProvider::class)->getMock();
         $git->method('getCurrentBranch')->willReturn('develop');
@@ -288,7 +235,7 @@ class ProjectTest extends TestCase
             '1.0.0',
             '1.1.0'
         ]);
-        /** @var GitProvider $git */
+
         $project = new Project($rootPackage, $git);
         $this->assertEquals("2.0.0", $project->getNextReleaseVersion());
     }
@@ -296,7 +243,6 @@ class ProjectTest extends TestCase
     public function testGetVersionWithMultipleMajorVersions(): void
     {
         // Arrange
-        /** @var RootPackageInterface&MockObject $rootPackage */
         $rootPackage = $this->getMockBuilder(RootPackageInterface::class)->getMock();
         $rootPackage->method('getName')->willReturn('sitepark/foo');
         $rootPackage->method('getExtra')->willReturn([
@@ -305,7 +251,6 @@ class ProjectTest extends TestCase
             ]
         ]);
 
-        /** @var GitProvider&MockObject $git */
         $git = $this->getMockBuilder(GitProvider::class)->getMock();
         $git->method('getCurrentBranch')->willReturn('develop');
         $git->method('getVersions')->willReturn([

--- a/tests/ReleaseManagementTest.php
+++ b/tests/ReleaseManagementTest.php
@@ -95,9 +95,7 @@ class ReleaseManagementTest extends TestCase
         $releaseManagement = new ReleaseManagement($project, $executor);
 
         $releaseManagement->verifyRelease();
-
-        // Exception not thrown
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 
     public function testVerifyReleaseWithUnstableDependencies(): void
@@ -158,7 +156,9 @@ class ReleaseManagementTest extends TestCase
             );
             $files = new RecursiveIteratorIterator($dirObj, RecursiveIteratorIterator::CHILD_FIRST);
             foreach ($files as $path) {
-                $path->isDir() && !$path->isLink() ? rmdir($path->getPathname()) : unlink($path->getPathname());
+                if ($path instanceof \SplFileInfo) {
+                    $path->isDir() && !$path->isLink() ? rmdir($path->getPathname()) : unlink($path->getPathname());
+                }
             }
             rmdir($dirPath);
         }

--- a/tests/ReleaseManagementTest.php
+++ b/tests/ReleaseManagementTest.php
@@ -3,6 +3,9 @@
 namespace SP\Composer\Project;
 
 use FilesystemIterator;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\BeforeClass;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
@@ -10,9 +13,7 @@ use RecursiveIteratorIterator;
 use RuntimeException;
 use SP\Composer\Project\Git\Executor;
 
-/**
- * @covers \SP\Composer\Project\ReleaseManagement
- */
+#[CoversClass(ReleaseManagement::class)]
 class ReleaseManagementTest extends TestCase
 {
     private const GIT_BASE = "var/test/ReleaseManagementTest/gitrepo";
@@ -21,9 +22,7 @@ class ReleaseManagementTest extends TestCase
 
     private const TEST_FILE = "var/test/ReleaseManagementTest/gitrepo/file.txt";
 
-    /**
-     * @beforeClass
-     */
+    #[BeforeClass]
     public static function initGitRepoDir(): void
     {
         self::rmdir(self::GIT_BASE);
@@ -64,17 +63,13 @@ class ReleaseManagementTest extends TestCase
         $executor->exec('git push origin');
     }
 
-    /**
-     * @before
-     */
+    #[Before]
     public static function restoreGitRepository(): void
     {
         $executor = new Executor(self::GIT_BASE);
         $executor->exec('git restore .');
     }
-        /**
-     * @throws Exception
-     */
+
     public function testConstruct(): void
     {
 
@@ -91,9 +86,6 @@ class ReleaseManagementTest extends TestCase
         $this->assertTrue($uncommitedChanges);
     }
 
-    /**
-     * @throws Exception
-     */
     public function testVerifyRelease(): void
     {
 
@@ -108,9 +100,6 @@ class ReleaseManagementTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * @throws Exception
-     */
     public function testVerifyReleaseWithUnstableDependencies(): void
     {
 
@@ -123,9 +112,6 @@ class ReleaseManagementTest extends TestCase
         $releaseManagement->verifyRelease();
     }
 
-    /**
-     * @throws Exception
-     */
     public function testStartHotfix(): void
     {
 
@@ -144,9 +130,6 @@ class ReleaseManagementTest extends TestCase
         $this->assertContains('hotfix/1.1.x', $branches);
     }
 
-    /**
-     * @throws Exception
-     */
     public function testRelease(): void
     {
 


### PR DESCRIPTION
- Fixes deprecation warning in PHP 8.4 about nullable default arguments
- Allow usage of symfony/console 7
- Update dependencies and tools
- Migrate to PHPStan 2 and bump phpstan level to 9
- Migrated tests to use Attributes instead of annotations
- Show Details about Errors/Warnings/Deprecations/Notices in PHPUnit