### PR TITLE
fix: re-add ability to ignore specific dependencies for verifyRelease

### DIFF
--- a/src/ReleaseManagement.php
+++ b/src/ReleaseManagement.php
@@ -26,10 +26,12 @@ class ReleaseManagement
             $this->project->getPackage()->getExtra()['verify-release']['allowed-stabilities'] ?? []
         );
 
-        $unstable = $this->project->getUnstableDependencies([
-            // See: https://github.com/Roave/SecurityAdvisories#stability
-            'roave/security-advisories'
-        ], $allowedStability);
+        $ignored = array_merge(
+            ['roave/security-advisories'],
+            $this->project->getPackage()->getExtra()['verify-release']['ignored'] ?? []
+        );
+
+        $unstable = $this->project->getUnstableDependencies($ignored, $allowedStability);
         if (count($unstable) > 0) {
             throw new \RuntimeException(
                 'There are unstable dependencies:' . "\n\n" .


### PR DESCRIPTION
This was already implemented, but got [removed](https://github.com/sitepark/composer-project/commit/a42f6e6528f7c6d2b62615e31069be733c628d0e) by accident

